### PR TITLE
Additional failed login suffix

### DIFF
--- a/filter.d/proxmox-backup-server.conf
+++ b/filter.d/proxmox-backup-server.conf
@@ -13,7 +13,7 @@ before = common.conf
 
 [Definition]
 
-__suffix_failed_login = (AUTH_ERR|invalid credentials).?
+__suffix_failed_login = (AUTH_ERR|invalid credentials|user account disabled or expired).?
 
 failregex = authentication failure; rhost=<HOST>.*msg=%(__suffix_failed_login)s
 


### PR DESCRIPTION
This PR adds support for disabled, expired or none existent account failed logins. Currently you can try login as a non existent account and you won't trigger fail2ban.

Example log of trying none existent user.
```
2022-02-27T00:19:41+00:00: authentication failure; rhost=[::ffff:1.1.1.1]:64704 user=weeb@pbs msg=user account disabled or expired.
```