### PR TITLE
added missing filter

### DIFF
--- a/jail.d/proxmox-backup-server.conf
+++ b/jail.d/proxmox-backup-server.conf
@@ -5,4 +5,4 @@ maxretry = 3
 enabled = true
 port    = 8007
 logpath = /var/log/proxmox-backup/api/auth.log
-
+filter = proxmox-backup-server


### PR DESCRIPTION
It doesn't work without a filter in the jail config.
Credit to:  mhadm
https://forum.proxmox.com/threads/working-fail2ban-webauth-config.128551